### PR TITLE
Add banned magic items from Bigby

### DIFF
--- a/content_catalog.md
+++ b/content_catalog.md
@@ -6739,3 +6739,11 @@ GCC-JOYCE-01 Weekend at Strahd’s
 - Tinderstrike
 - Waythe
 - Windvane
+- Adze of Annam
+- Bigby’s Beneficent Bracelet
+- Bloodshed Blade
+- Crown of the Wrath Bringer
+- Delver’s Claws
+- Ring of Amity
+- Harp of Gilded Plenty
+- Helm of Perfect Potential


### PR DESCRIPTION
Dodano przedmioty magiczne z Bigby Presents: Glory of the Giants do listy przedmiotów z banowanych jako wynik głosowania 43a - https://discord.com/channels/402539300824154112/1090237104291852288/1147159364759736463