### PR TITLE
Planescape feats added

### DIFF
--- a/basic_rules.md
+++ b/basic_rules.md
@@ -96,13 +96,14 @@ Każda nowa postać w OPK tworzona jest na Poziomie 1 i na takim rozpoczyna udzi
 - One Grung Above
 - podklasa Lunar Sorcerer z podręcznika Dragonlance: Shadow of the Dragon Queen (DL:SotDQ)
 - podklasa Path of the Giant i featy z Bigby Presents: Glory of the Giants (BP:GotG)
+- featy z Planescape: Adventures in the Multiverse (PS:AitM)
 
 Następujące opcje postaci **NIE** są dozwolone:
 
 - Custom Lineage (TCoE)
 - rasa Changeling (MP:MotM)
 - rasa Shifter (MP:MotM)
-- backgroundy z BP:GotG
+- backgroundy z BP:GotG oraz PS:AitM
 
 Niektóre rasy pojawiają się na powyższej liście podręczników w kilku wersjach (np. występują w VGtM lub MToF i jednocześnie w MP:MotM): w takim wypadku gracz może wybrać dla swojej postaci dowolną wersję tej rasy.
 

--- a/basic_rules.md
+++ b/basic_rules.md
@@ -96,7 +96,7 @@ Każda nowa postać w OPK tworzona jest na Poziomie 1 i na takim rozpoczyna udzi
 - One Grung Above
 - podklasa Lunar Sorcerer z podręcznika Dragonlance: Shadow of the Dragon Queen (DL:SotDQ)
 - podklasa Path of the Giant i featy z Bigby Presents: Glory of the Giants (BP:GotG)
-- featy z Planescape: Adventures in the Multiverse (PS:AitM)
+- featy z Planescape: Adventures in the Multiverse (PS:AitM) (nie obowiązuje ograniczenie kampanii feata Scion of the Outer Planes)
 
 Następujące opcje postaci **NIE** są dozwolone:
 


### PR DESCRIPTION
Zgodnie z wynikiem [głosowania #59](https://discord.com/channels/402539300824154112/1090237104291852288/1183750737692459088), featy z Planescape: Adventures in the Multiverse zostają dopuszczone jak opcja dla postaci.